### PR TITLE
Fix UB in add_*_mconstraint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl<F: ObjFn<T>, T> Nlopt<F, T> {
         m: usize,
         constraint: G,
         user_data: U,
-        tolerance: f64,
+        tolerance: &[f64],
     ) -> OptResult {
         self.add_mconstraint(m, constraint, user_data, tolerance, true)
     }
@@ -476,7 +476,7 @@ impl<F: ObjFn<T>, T> Nlopt<F, T> {
         m: usize,
         constraint: G,
         user_data: U,
-        tolerance: f64,
+        tolerance: &[f64],
     ) -> OptResult {
         self.add_mconstraint(m, constraint, user_data, tolerance, false)
     }
@@ -486,9 +486,10 @@ impl<F: ObjFn<T>, T> Nlopt<F, T> {
         m: usize,
         constraint: G,
         user_data: U,
-        tolerance: f64,
+        tolerance: &[f64],
         is_equality: bool,
     ) -> OptResult {
+        assert_eq!(m, tolerance.len());
         let mconstraint = MConstraintCfg {
             constraint,
             user_data,
@@ -501,7 +502,7 @@ impl<F: ObjFn<T>, T> Nlopt<F, T> {
                     m as c_uint,
                     Some(mfunction_raw_callback::<G, U>),
                     ptr,
-                    &tolerance,
+                    tolerance.as_ptr(),
                 )
             } else {
                 sys::nlopt_add_inequality_mconstraint(
@@ -509,7 +510,7 @@ impl<F: ObjFn<T>, T> Nlopt<F, T> {
                     m as c_uint,
                     Some(mfunction_raw_callback::<G, U>),
                     ptr,
-                    &tolerance,
+                    tolerance.as_ptr(),
                 )
             }
         };
@@ -1021,7 +1022,7 @@ mod tests {
             3,
             |r: &mut [f64], x: &[f64], _: Option<&mut [f64]>, _: &mut ()| m_ineq_constraint(r, x),
             (),
-            1e-6,
+            &[1e-6;3],
         ).unwrap();
 
         // TODO if we use two eq constraints, it doesn't converge *shrug*
@@ -1029,7 +1030,7 @@ mod tests {
             1,
             |r: &mut [f64], x: &[f64], _: Option<&mut [f64]>, _: &mut ()| m_eq_constraint(r, x),
             (),
-            1e-6,
+            &[1e-6;1],
         ).unwrap();
 
         opt.set_xtol_rel(1e-6).unwrap();


### PR DESCRIPTION
NLopt's nlopt_add_*_mconstraint functions take a pointer to an array
of tolerances, one for each constraint; they copy that array.

rust-nlopt mistakenly passed a pointer to a single f64.  As a result
NLopt would make out-of-bounds array accesses.  Often the values read
would be negative, giving NLOPT_INVALID_ARGS.

There are two possible ways to fix this: 1. simply fix the rust-nlopt
API to take an appropriate slice; 2. make the existing functions copy
the single provided toleranc value and provide 2 new functions for
when the tolerances are not all the same.

I have chosen (1) because it is less work and because the declared
version of this crate is 0.x, so this would not break semver.

Two more arguments that could be made in support of this decision:

Anyone calling these functions is currently experiencing UB,
including (in my experience) random invalid argument errors.  So
probably few people are using these entrypoints.

The new API corresponds to the NLopt API.

Signed-off-by: Ian Jackson <ijackson@chiark.greenend.org.uk>